### PR TITLE
Update sbt

### DIFF
--- a/sbt
+++ b/sbt
@@ -8,7 +8,7 @@ sbtrepo=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch
 
 if [ ! -f $sbtjar ]; then
   echo "downloading $sbtjar" 1>&2
-  if ! curl --silent --fail --remote-name $sbtrepo/$sbtver/$sbtjar; then
+  if ! curl --location --silent --fail --remote-name $sbtrepo/$sbtver/$sbtjar; then
     exit 1
   fi
 fi


### PR DESCRIPTION
Problem: bad sbt-launch.jar. delete sbt-launch.jar and run ./sbt again.

Typesafe recently moved their jar repo to bintray.
Now every jar fetching command (curl) fails because curl doesn't
follow Http 302 by default.

Solution

Add the required parameter to curl to follow the 302 redirect.
