### PR TITLE
Fixed NxParser repository link & version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := Version.scala
 
 resolvers ++= List(
   "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository",
-  "NxParser" at "http://nxparser.googlecode.com/svn/repository"
+  "NxParser" at "https://mvnrepository.com/artifact/org.semanticweb.yars/nxparser"
 )
 
 scalacOptions ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Version {
   val logback      = "1.1.2"
   val metrics      = "3.0.2"
   val neo4j        = "2.0.2"
-  val nxParser     = "1.2.5"
+  val nxParser     = "1.2.1"
   val slf4j        = "1.7.7"
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Version {
   val logback      = "1.1.2"
   val metrics      = "3.0.2"
   val neo4j        = "2.0.2"
-  val nxParser     = "1.2.1"
+  val nxParser     = "1.2.10"
   val slf4j        = "1.7.7"
 }
 


### PR DESCRIPTION
The old repository link was broken.
Found a repo link for a slightly older version (1.2.10).
