### PR TITLE
Upgrade to Neo4j 3.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,15 +8,15 @@ object Version {
   val hppc         = "0.6.0"
   val logback      = "1.1.2"
   val metrics      = "3.0.2"
-  val neo4j        = "2.0.2"
+  val neo4j        = "3.3.1"
   val nxParser     = "1.2.10"
   val slf4j        = "1.7.7"
 }
 
 object Library {
   val neo4jExcludes = List(
-    ExclusionRule("org.neo4j", "neo4j-cypher-compiler-1.9"),
     ExclusionRule("org.neo4j", "neo4j-cypher-compiler-2.0"),
+    ExclusionRule("org.neo4j", "neo4j-cypher-compiler-3.1"),
     ExclusionRule("org.neo4j", "neo4j-cypher"),
     ExclusionRule("org.neo4j", "neo4j-udc"),
     ExclusionRule("org.neo4j", "neo4j-graph-algo"),

--- a/src/main/scala/de/knutwalker/dbpedia/impl/FastBatchGraphComponent.scala
+++ b/src/main/scala/de/knutwalker/dbpedia/impl/FastBatchGraphComponent.scala
@@ -63,7 +63,7 @@ trait FastBatchGraphComponent extends GraphComponent {
 
     private val inserter = {
       val config = inserterConfig
-      BatchInserters.inserter(DB_PATH, config)
+      BatchInserters.inserter(new File(DB_PATH), config)
     }
 
     if (settings.createDeferredIndices) {

--- a/src/main/scala/de/knutwalker/dbpedia/impl/FastBatchGraphComponent.scala
+++ b/src/main/scala/de/knutwalker/dbpedia/impl/FastBatchGraphComponent.scala
@@ -3,6 +3,7 @@ package de.knutwalker.dbpedia.impl
 import com.carrotsearch.hppc.{ ObjectLongMap, ObjectLongOpenHashMap }
 import de.knutwalker.dbpedia.components.{ MetricsComponent, SettingsComponent, GraphComponent }
 import java.util
+import java.io.File
 import org.neo4j.graphdb.{ DynamicLabel, Label, RelationshipType }
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.unsafe.batchinsert.BatchInserters


### PR DESCRIPTION
These edits allow to import DbPedia into Neo4j v. 3.3.1.
Although I'm not 100% sure about the exclusion rules.